### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commonmarker (0.17.13)
+    commonmarker (>= 0.23.4)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.5)
     dnsruby (1.61.3)


### PR DESCRIPTION
Fix security vulnerability "Integer overflow in cmark-gfm table parsing extension leads to heap memory corruption"